### PR TITLE
travis: build only on the master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,6 @@ cache:
   directories:
   - node_modules
 script: npm run test
+branches:
+  only:
+    - master


### PR DESCRIPTION
Limit `travis` to only run builds on the `master` branch, otherwise it will build even a newly created branch
